### PR TITLE
Fix chromeFlags

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -125,7 +125,7 @@ export default class ServerlessChrome {
           .replace("'REPLACE_WITH_HANDLER_REQUIRE'", `require('./${originalFileRenamed}')`)
           .replace(
             "'REPLACE_WITH_OPTIONS'",
-            `{ ${chromeFlags.length ? `chromeFlags: ['${chromeFlags.join("', '")}']` : ''} }`
+            `{ ${chromeFlags.length ? `flags: ['${chromeFlags.join("', '")}']` : ''} }`
           )
           .replace(/REPLACE_WITH_EXPORT_NAME/gm, exportName)
 


### PR DESCRIPTION
Fixes use of the chromeFlags configuration.

`flags` is expected here (vs `chromeFlags`): https://github.com/adieuadieu/serverless-chrome/blob/develop/packages/lambda/src/index.js#L16

