### PR TITLE
Fix remove Chrome zip file after extract

### DIFF
--- a/packages/lambda/scripts/postinstall.js
+++ b/packages/lambda/scripts/postinstall.js
@@ -82,7 +82,7 @@ function getChromium () {
   return get(ZIP_URL, DOWNLOAD_PATH)
     .then(() => extractFile(DOWNLOAD_PATH, EXTRACT_PATH))
     .then(() => console.log('Completed Headless Chromium download.'))
-    .then(unlink(DOWNLOAD_PATH))
+    .then(() => unlink(DOWNLOAD_PATH))
 }
 
 if (require.main === module) {


### PR DESCRIPTION
I noticed you added deletion of zip file after extraction, but it was ran right away instead of when the promise was resolved, so here's a PR to fix it.