### PR TITLE
fix flag

### DIFF
--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -44,7 +44,7 @@ const CDP = require('chrome-remote-interface')
 
 module.exports.handler = function handler (event, context, callback) {
   launchChrome({
-    flags: ['--window-size=1280x1696', '--hide-scrollbars']
+    flags: ['--window-size=1440,900', '--hide-scrollbars']
   })
   .then((chrome) => {
     // Chrome is now running on localhost:9222


### PR DESCRIPTION
according to [os](https://stackoverflow.com/questions/13436855/launch-google-chrome-from-the-command-line-with-specific-window-coordinates), the correct syntax for window size is using ',' instead of 'x'.