### PR TITLE
Guard against potential undefined error

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -130,7 +130,7 @@ export default class ServerlessChrome {
 
       const originalFileRenamed = `${utils.generateShortId()}___${fileName}`
 
-      const customPluginOptions = service.custom.chrome || {}
+      const customPluginOptions = (service.custom && service.custom.chrome) || {}
 
       const launcherOptions = {
         ...customPluginOptions,


### PR DESCRIPTION
I was receiving the error: `Cannot read property 'chrome' of undefined` when trying to run my serverless function, and did some digging and noticed that `service.custom` may be undefined, and adding this check, like the one that exists a few lines above, guards against it.