### PR TITLE
use SIGKILL

### DIFF
--- a/packages/lambda/src/launcher.js
+++ b/packages/lambda/src/launcher.js
@@ -175,7 +175,7 @@ export default class Launcher {
         debug('Killing all Chrome Instances')
 
         try {
-          process.kill(-this.chrome.pid)
+          process.kill(-this.chrome.pid, 'SIGKILL')
         } catch (err) {
           debug(`Chrome could not be killed ${err.message}`)
         }


### PR DESCRIPTION
This is a small change in the way chrome process is being terminated. using SIGKILL shows improve stability and prevent cases where the frozen container didn't finish cleaning up the chrome process before terminating.
I've seen multiple discussions about this issue over chromeless and serverless-chrome. and I think this would go a long way in making serverless chrome behavior predictable and less prone to issues with lambda containers reuse.