### PR TITLE
don't use /var/task/headless-chromium when running locally

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -135,7 +135,7 @@ export default class ServerlessChrome {
       const launcherOptions = {
         ...customPluginOptions,
         flags: customPluginOptions.flags || [],
-        chromePath: this.webpack ? '/var/task/headless-chromium' : undefined,
+        chromePath: (this.webpack && !process.env.IS_LOCAL) ? '/var/task/headless-chromium' : undefined,
       }
 
       // Read in the wrapper handler code template


### PR DESCRIPTION
If you are using webpack, this plugin assumes headless-chromium is present at /var/task/headless-chromium
But this isn't true when running locally with `invoke local`.

I'm using the following plugins:
```
plugins:
  - serverless-plugin-chrome
  - serverless-webpack
```

Running `invoke local`:
```
@serverless-chrome/lambda Spawning headless shell
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
@serverless-chrome/lambda Error trying to spawn chrome: TypeError: Cannot read property 'toString' of undefined
    at Launcher.<anonymous> (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:170:63)
    at next (native)
    at /Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:12:71
    at __awaiter (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:8:12)
    at spawnPromise (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:155:41)
    at Launcher.<anonymous> (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:173:16)
    at next (native)
    at /Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:12:71
    at __awaiter (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:8:12)
    at Launcher.spawnProcess (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:153:16)
    at Launcher.<anonymous> (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:148:35)
    at throw (native)
    at rejected (/Users/dholdren/projects/test_serverless_chrome/node_modules/chrome-launcher/dist/chrome-launcher.js:10:65)
    at process._tickDomainCallback (internal/process/next_tick.js:135:7)
@serverless-chrome/lambda stdout log:
@serverless-chrome/lambda stderr log:
Error occured in serverless-plugin-chrome wrapper when trying to ensure Chrome for handler() handler. { flags: [], chromePath: '/var/task/headless-chromium' } Error: Unable to start Chrome. If you have the DEBUG env variable set,there will be more in the logs.
    at /Users/dholdren/projects/test_serverless_chrome/node_modules/@serverless-chrome/lambda/dist/bundle.cjs.js:317:13
    at throw (native)
    at step (/Users/dholdren/projects/test_serverless_chrome/node_modules/@serverless-chrome/lambda/dist/bundle.cjs.js:258:191)
    at /Users/dholdren/projects/test_serverless_chrome/node_modules/@serverless-chrome/lambda/dist/bundle.cjs.js:258:402
    at process._tickDomainCallback (internal/process/next_tick.js:135:7)
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: spawn /var/task/headless-chromium ENOENT
    at exports._errnoException (util.js:1018:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:367:16)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
```