### PR TITLE
Update the right syntax for flag '--window-size'

### DIFF
--- a/examples/serverless-framework/aws/serverless.yml
+++ b/examples/serverless-framework/aws/serverless.yml
@@ -17,7 +17,7 @@ plugins:
 custom:
   chrome:
     flags:
-      - --window-size=1280x1696 # Letter size
+      - --window-size=1280,1696 # Letter size
       - --hide-scrollbars
 
 functions:

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -44,7 +44,7 @@ const CDP = require('chrome-remote-interface')
 
 module.exports.handler = function handler (event, context, callback) {
   launchChrome({
-    flags: ['--window-size=1280x1696', '--hide-scrollbars']
+    flags: ['--window-size=1280,1696', '--hide-scrollbars']
   })
   .then((chrome) => {
     // Chrome is now running on localhost:9222

--- a/packages/serverless-plugin/README.md
+++ b/packages/serverless-plugin/README.md
@@ -97,7 +97,7 @@ plugins:
 custom:
   chrome:
     flags:
-      - --window-size=1280x1696 # Letter size
+      - --window-size=1280,1696 # Letter size
       - --hide-scrollbars
       - --ignore-certificate-errors
     functions:

--- a/packages/serverless-plugin/integration-test/serverless.yml
+++ b/packages/serverless-plugin/integration-test/serverless.yml
@@ -15,7 +15,7 @@ plugins:
 custom:
   chrome:
     flags:
-      - --window-size=1280x1696 # Letter size
+      - --window-size=1280,1696 # Letter size
       - --hide-scrollbars
       - --ignore-certificate-errors
     functions:


### PR DESCRIPTION
As per its original implementation: https://cs.chromium.org/chromium/src/headless/app/headless_shell_switches.cc?l=109

PR #91 partially implemented the change, I've just amended it in the missing places.