### PR TITLE
Fix #131 destructuring of query parameters

### DIFF
--- a/examples/serverless-framework/aws/src/handlers/pdf.js
+++ b/examples/serverless-framework/aws/src/handlers/pdf.js
@@ -9,12 +9,11 @@ import log from '../utils/log'
 import pdf, { makePrintOptions } from '../chrome/pdf'
 
 export default async function handler (event, context, callback) {
+  const queryStringParameters = event.queryStringParameters || {}
   const {
-    queryStringParameters: {
-      url = 'https://github.com/adieuadieu/serverless-chrome',
-      ...printParameters
-    },
-  } = event
+    url = 'https://github.com/adieuadieu/serverless-chrome',
+    ...printParameters
+  } = queryStringParameters
   const printOptions = makePrintOptions(printParameters)
   let data
 

--- a/examples/serverless-framework/aws/src/handlers/requestLogger.js
+++ b/examples/serverless-framework/aws/src/handlers/requestLogger.js
@@ -4,9 +4,10 @@ import Cdp from 'chrome-remote-interface'
 const LOAD_TIMEOUT = 1000 * 30
 
 export default async function handler (event, context, callback) {
+  const queryStringParameters = event.queryStringParameters || {}
   const {
-    queryStringParameters: { url = 'https://github.com/adieuadieu/serverless-chrome' },
-  } = event
+    url = 'https://github.com/adieuadieu/serverless-chrome',
+  } = queryStringParameters
   const requestsMade = []
 
   const [tab] = await Cdp.List()

--- a/examples/serverless-framework/aws/src/handlers/screencast.js
+++ b/examples/serverless-framework/aws/src/handlers/screencast.js
@@ -227,7 +227,8 @@ export async function makeVideo (url, options = {}, invokeid = '') {
 }
 
 export default async function handler (event, { invokeid }, callback) {
-  const { queryStringParameters: { url, ...printParameters } } = event
+  const queryStringParameters = event.queryStringParameters || {}
+  const { url, ...printParameters } = queryStringParameters
   const options = makePrintOptions(printParameters)
   let result = {}
 

--- a/examples/serverless-framework/aws/src/handlers/screenshot.js
+++ b/examples/serverless-framework/aws/src/handlers/screenshot.js
@@ -2,12 +2,11 @@ import log from '../utils/log'
 import screenshot from '../chrome/screenshot'
 
 export default async function handler (event, context, callback) {
+  const queryStringParameters = event.queryStringParameters || {}
   const {
-    queryStringParameters: {
-      url = 'https://github.com/adieuadieu/serverless-chrome',
-      mobile = false,
-    },
-  } = event
+    url = 'https://github.com/adieuadieu/serverless-chrome',
+    mobile = false,
+  } = queryStringParameters
 
   let data
 


### PR DESCRIPTION
Not sure if the API of aws lambda changed, but the
queryStringParameters of event is null, which makes it impossible to
destructure params, even with default values.