### PR TITLE
Check that process exists before assuming Chrome is running

### DIFF
--- a/packages/lambda/src/index.js
+++ b/packages/lambda/src/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 // import path from 'path'
 import LambdaChromeLauncher from './launcher'
-import { debug } from './utils'
+import { debug, processExists } from './utils'
 import DEFAULT_CHROME_FLAGS from './flags'
 
 const DEVTOOLS_PORT = 9222
@@ -28,7 +28,7 @@ export default async function launch ({
 } = {}) {
   const chromeFlags = [...DEFAULT_CHROME_FLAGS, ...flags]
 
-  if (!chromeInstance) {
+  if (!chromeInstance || !processExists(chromeInstance.pid)) {
     if (process.env.AWS_EXECUTION_ENV || forceLambdaLauncher) {
       chromeInstance = new LambdaChromeLauncher({
         chromePath,

--- a/packages/lambda/src/utils.js
+++ b/packages/lambda/src/utils.js
@@ -24,3 +24,18 @@ export function makeTempDir () {
     .toString()
     .trim()
 }
+
+/**
+ * Checks if a process currently exists by process id.
+ * @param pid number process id to check if exists
+ * @returns boolean true if process exists, false if otherwise
+ */
+export function processExists (pid) {
+  let exists = true
+  try {
+    process.kill(pid, 0)
+  } catch (error) {
+    exists = false
+  }
+  return exists
+}

--- a/packages/serverless-plugin/package.json
+++ b/packages/serverless-plugin/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
   "dependencies": {
-    "@serverless-chrome/lambda": "1.0.0-51",
+    "@serverless-chrome/lambda": "defendertx/serverless-chrome/packages/lambda#feature/pid-check",
     "fs-p": "2.0.0",
     "globby": "6.1.0"
   },

--- a/packages/serverless-plugin/package.json
+++ b/packages/serverless-plugin/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
   "dependencies": {
-    "@serverless-chrome/lambda": "defendertx/serverless-chrome/packages/lambda#feature/pid-check",
+    "@serverless-chrome/lambda": "1.0.0-51",
     "fs-p": "2.0.0",
     "globby": "6.1.0"
   },


### PR DESCRIPTION
I believe this PR will fix Issue #153 by ensuring that the chromeInstance is still running (or at least that the pid still exists). If not, it should continue with the normal logic of creating a new LambdaChromeLauncher object and launching a new chrome process.