### PR TITLE
feat: Add type definitions for typescript

### DIFF
--- a/packages/lambda/index.d.ts
+++ b/packages/lambda/index.d.ts
@@ -1,0 +1,22 @@
+export default function ServerlessChromeLambda(options?: Option): Promise<ServerLessChrome>;
+
+type Option = {
+  flags?: string[],
+  chromePath?: string,
+  port?: number,
+  forceLambdaLauncher?: boolean,
+};
+
+type ServerLessChrome = {
+  pid: number,
+  port: number,
+  url: string,
+  log: string,
+  errorLog: string,
+  pidFile: string,
+  metaData: {
+    launchTime: number,
+    didLaunch: boolean,
+  },
+  kill: () => void,
+};

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -18,6 +18,7 @@
     "dist/bundle.es.js",
     "scripts/postinstall.js"
   ],
+  "types": "index.d.ts",
   "repository": "git@github.com:adieuadieu/serverless-chrome.git",
   "bugs": {
     "url": "https://github.com/adieuadieu/serverless-chrome/issues"


### PR DESCRIPTION
I want to develop my project using `@serverless-chrome/lambda` on typescript.
But, it did not solve types (like this image).

![2018-12-14 0 28 31](https://user-images.githubusercontent.com/12580072/49948667-3c9ce700-ff37-11e8-8b5e-25e23d266773.png)

I did not know how to make it, but  I make a definition file on trial.
Please review and comment my type definition.

If it has some problems, please close my pull request.