### PR TITLE
feat: add support for packaging individually in serverless-plugin

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -54,12 +54,26 @@ export default class ServerlessChrome {
   }
 
   async webpackPackageBinaries () {
-    const { servicePath } = this.serverless.config
+    const { config: { servicePath }, service } = this.serverless
+    const packagedIdividually = service.package && service.package.individually
 
-    await fs.copy(
-      path.join(servicePath, 'node_modules/@serverless-chrome/lambda/dist/headless-chromium'),
-      path.resolve(servicePath, '.webpack/service/headless-chromium')
-    )
+    if (packagedIdividually) {
+      const functionsToCopyTo =
+        (service.custom && service.custom.chrome && service.custom.chrome.functions) ||
+        service.getAllFunctions()
+
+      await Promise.all(functionsToCopyTo.map(async (functionName) => {
+        await fs.copy(
+          path.join(servicePath, 'node_modules/@serverless-chrome/lambda/dist/headless-chromium'),
+          path.resolve(servicePath, `.webpack/${functionName}/headless-chromium`)
+        )
+      }))
+    } else {
+      await fs.copy(
+        path.join(servicePath, 'node_modules/@serverless-chrome/lambda/dist/headless-chromium'),
+        path.resolve(servicePath, '.webpack/service/headless-chromium')
+      )
+    }
   }
 
   async beforeCreateDeploymentArtifacts () {


### PR DESCRIPTION
Serverless webpack introduced individual packages for each function: [https://github.com/serverless-heaven/serverless-webpack#optimization--individual-packaging-per-function](url). But servless-chrome-plugin do not support this feature as it copies headless-chromium binary to the root of service folder when packaging.

This fix introduce a possibility to use 
`package:
  individually: true`
as a serverless-webpack option by coping an instance of headless-chromium binary to each function folder that is enabled in service.custom.chrome.functions