### PR TITLE
Disable DEBUG flag '--v=99'

### DIFF
--- a/packages/lambda/src/flags.js
+++ b/packages/lambda/src/flags.js
@@ -1,5 +1,5 @@
 const LOGGING_FLAGS = process.env.DEBUG
-  ? ['--enable-logging', '--log-level=0', '--v=99']
+  ? ['--enable-logging', '--log-level=0']
   : []
 
 export default [


### PR DESCRIPTION
Disable flag that is causing [AWS example](https://github.com/adieuadieu/serverless-chrome/tree/master/examples/serverless-framework/aws) to fail.

Related issues:
- https://github.com/adieuadieu/serverless-chrome/issues/179
- https://github.com/adieuadieu/serverless-chrome/issues/170