### PR TITLE
Fix symlink creation on Windows

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -112,7 +112,8 @@ export default class ServerlessChrome {
       ) {
         fs.symlinkSync(
           path.resolve('node_modules'),
-          path.resolve(path.join(BUILD_FOLDER, 'node_modules'))
+          path.resolve(path.join(BUILD_FOLDER, 'node_modules')),
+          'junction'
         )
       }
 


### PR DESCRIPTION
See https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback for more information.