### PR TITLE
Update package name in error message

### DIFF
--- a/packages/serverless-plugin/src/utils.js
+++ b/packages/serverless-plugin/src/utils.js
@@ -3,14 +3,14 @@ import { SUPPORTED_PROVIDERS, SUPPORTED_RUNTIMES } from './constants'
 
 export function throwIfUnsupportedProvider (provider) {
   if (!SUPPORTED_PROVIDERS.includes(provider)) {
-    throw new Error('The "serverless-plugin-headless-chrome" plugin currently only supports AWS Lambda. ' +
+    throw new Error('The "serverless-plugin-chrome" plugin currently only supports AWS Lambda. ' +
         `Your service is using the "${provider}" provider.`)
   }
 }
 
 export function throwIfUnsupportedRuntime (runtime) {
   if (!SUPPORTED_RUNTIMES.includes(runtime)) {
-    throw new Error('The "serverless-plugin-headless-chrome" plugin only supports the Node.js 6.10 or 8.10 runtimes. ' +
+    throw new Error('The "serverless-plugin-chrome" plugin only supports the Node.js 6.10 or 8.10 runtimes. ' +
         `Your service is using the "${runtime}" provider.`)
   }
 }


### PR DESCRIPTION
Change `serverless-plugin-headless-chrome` to `serverless-plugin-chrome`.

The error message confused me because it was talking about `serverless-plugin-headless-chrome`, a package that I could not find. :)