### PR TITLE
Update to amazonlinux:2.0.20191016.

### DIFF
--- a/check-chrome.sh
+++ b/check-chrome.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./packages/lambda/scripts/latest-versions.sh

--- a/packages/lambda/builds/chromium/build/Dockerfile
+++ b/packages/lambda/builds/chromium/build/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -d --rm --name headless-chromium -p 9222:9222 adieuadieu/headless-chromium-for-aws-lambda
 #
 
-FROM amazonlinux:2017.03
+FROM amazonlinux:2018.03
 
 # ref: https://chromium.googlesource.com/chromium/src.git/+refs
 ARG VERSION

--- a/packages/lambda/builds/chromium/build/Dockerfile
+++ b/packages/lambda/builds/chromium/build/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -d --rm --name headless-chromium -p 9222:9222 adieuadieu/headless-chromium-for-aws-lambda
 #
 
-FROM amazonlinux:2018.03
+FROM amazonlinux:2.0.20191016.0-with-sources
 
 # ref: https://chromium.googlesource.com/chromium/src.git/+refs
 ARG VERSION

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -34,7 +34,7 @@ printf "LANG=en_US.utf-8\nLC_ALL=en_US.utf-8" >> /etc/environment
 #   libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel \
 #   pam-devel pango-devel pciutils-devel pulseaudio-libs-devel \
 #   zlib zlib-devel httpd mod_ssl php php-cli python-psutil wdiff --enablerepo=epel
-yum groupinstall "Development Tools"
+yum groupinstall -y "Development Tools"
 yum install -y \
   alsa-lib-devel atk-devel binutils bison bluez-libs-devel brlapi-devel bzip2 bzip2-devel cairo-devel cmake cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel glibc gperf gtk3-devel htop httpd java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python tar zlib zlib-devel
 

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -21,8 +21,7 @@ VERSION=${VERSION:-master}
 printf "LANG=en_US.utf-8\nLC_ALL=en_US.utf-8" >> /etc/environment
 
 # install dependencies
-# yum groupinstall "Development Tools"
-yum install epel-release -y
+# yum install epel-release -y
 # yum install -y \
 #   git redhat-lsb python bzip2 tar pkgconfig atk-devel \
 #   alsa-lib-devel bison binutils brlapi-devel bluez-libs-devel \
@@ -35,9 +34,9 @@ yum install epel-release -y
 #   libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel \
 #   pam-devel pango-devel pciutils-devel pulseaudio-libs-devel \
 #   zlib zlib-devel httpd mod_ssl php php-cli python-psutil wdiff --enablerepo=epel
-
+yum groupinstall "Development Tools"
 yum install -y \
-  alsa-lib-devel atk-devel binutils bison bluez-libs-devel brlapi-devel bzip2 bzip2-devel cairo-devel cmake cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel glibc gperf gtk3-devel htop httpd java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python tar zlib zlib-devel --enablerepo=epel
+  alsa-lib-devel atk-devel binutils bison bluez-libs-devel brlapi-devel bzip2 bzip2-devel cairo-devel cmake cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel glibc gperf gtk3-devel htop httpd java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python tar zlib zlib-devel
 
 mkdir -p build/chromium
 

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -21,7 +21,7 @@ VERSION=${VERSION:-master}
 printf "LANG=en_US.utf-8\nLC_ALL=en_US.utf-8" >> /etc/environment
 
 # install dependencies
-yum groupinstall "Development Tools"
+# yum groupinstall "Development Tools"
 yum install epel-release -y
 # yum install -y \
 #   git redhat-lsb python bzip2 tar pkgconfig atk-devel \

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -5,8 +5,8 @@
 # Build Chromium for Amazon Linux.
 # Assumes root privileges. Or, more likely, Docker—take a look at
 # the corresponding Dockerfile in this directory.
-# 
-# Requires 
+#
+# Requires
 #
 # Usage: ./build.sh
 #
@@ -102,7 +102,7 @@ strip -o "$BUILD_BASE/bin/headless-chromium" build/chromium/src/out/Headless/hea
 
 # Use UPX to package headless chromium
 # this adds 1-1.5 seconds of startup time so generally
-# not so great for use in AWS Lambda so we don't actually use it 
+# not so great for use in AWS Lambda so we don't actually use it
 # but left here in case someone finds it useful
 # yum install -y ucl ucl-devel --enablerepo=epel
 # cd build

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -21,19 +21,23 @@ VERSION=${VERSION:-master}
 printf "LANG=en_US.utf-8\nLC_ALL=en_US.utf-8" >> /etc/environment
 
 # install dependencies
+yum groupinstall "Development Tools"
 yum install epel-release -y
+# yum install -y \
+#   git redhat-lsb python bzip2 tar pkgconfig atk-devel \
+#   alsa-lib-devel bison binutils brlapi-devel bluez-libs-devel \
+#   bzip2-devel cairo-devel cups-devel dbus-devel dbus-glib-devel \
+#   expat-devel fontconfig-devel freetype-devel gcc-c++ GConf2-devel \
+#   glib2-devel glibc gperf glib2-devel gtk2-devel gtk3-devel \
+#   java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel \
+#   libgcc libgnome-keyring-devel libjpeg-devel libstdc++ \
+#   libX11-devel libXScrnSaver-devel libXtst-devel \
+#   libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel \
+#   pam-devel pango-devel pciutils-devel pulseaudio-libs-devel \
+#   zlib zlib-devel httpd mod_ssl php php-cli python-psutil wdiff --enablerepo=epel
+
 yum install -y \
-  git redhat-lsb python bzip2 tar pkgconfig atk-devel \
-  alsa-lib-devel bison binutils brlapi-devel bluez-libs-devel \
-  bzip2-devel cairo-devel cups-devel dbus-devel dbus-glib-devel \
-  expat-devel fontconfig-devel freetype-devel gcc-c++ GConf2-devel \
-  glib2-devel glibc.i686 gperf glib2-devel gtk2-devel gtk3-devel \
-  java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel \
-  libgcc.i686 libgnome-keyring-devel libjpeg-devel libstdc++.i686 \
-  libX11-devel libXScrnSaver-devel libXtst-devel \
-  libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel \
-  pam-devel pango-devel pciutils-devel pulseaudio-libs-devel \
-  zlib.i686 httpd mod_ssl php php-cli python-psutil wdiff --enablerepo=epel
+  alsa-lib-devel atk-devel binutils bison bluez-libs-devel brlapi-devel bzip2 bzip2-devel cairo-devel cmake cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel glibc gperf gtk3-devel htop httpd java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python tar zlib zlib-devel --enablerepo=epel
 
 mkdir -p build/chromium
 


### PR DESCRIPTION
This updates amazon linux to be able to build Chrome 75 and possibly newer, I haven't yet tested on 81 though.