### PR TITLE
Bump serverless-plugin-chrome to 1.0.0-55.3

### DIFF
--- a/examples/serverless-framework/aws/package.json
+++ b/examples/serverless-framework/aws/package.json
@@ -56,7 +56,7 @@
     "babel-preset-stage-3": "6.24.1",
     "babel-register": "6.26.0",
     "serverless": "1.24.1",
-    "serverless-plugin-chrome": "1.0.0-55",
+    "serverless-plugin-chrome": "1.0.0-55.3",
     "serverless-webpack": "4.0.0",
     "webpack": "3.8.1"
   },


### PR DESCRIPTION
Versions < 1.0.0-55.3 fails to run locally and even fails to start Chrome on AWS.