### PR TITLE
Upgrade to rely on `package.patterns` 

### DIFF
--- a/packages/serverless-plugin/package.json
+++ b/packages/serverless-plugin/package.json
@@ -55,6 +55,9 @@
     "rollup-plugin-babel": "3.0.4",
     "rollup-plugin-node-resolve": "3.3.0"
   },
+  "peerDependences": {
+    "serverless": "^2.32.0"
+  },
   "babel": {
     "sourceMaps": true,
     "presets": [

--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -102,6 +102,7 @@ export default class ServerlessChrome {
       service.getAllFunctions()
 
     service.package.include = service.package.include || []
+    service.package.patterns = service.package.patterns || []
 
     cli.log('Injecting Headless Chrome...')
 
@@ -130,7 +131,7 @@ export default class ServerlessChrome {
 
       // include any "extras" from the "include" section
       const files = await globby(
-        [...service.package.include, '**', '!node_modules/**'],
+        [...service.package.include, ...service.package.patterns, '**', '!node_modules/**'],
         {
           cwd: this.originalServicePath,
         }
@@ -153,7 +154,7 @@ export default class ServerlessChrome {
     }
 
     // Add our node_modules dependencies to the package includes
-    service.package.include = [...service.package.include, ...INCLUDES]
+    service.package.patterns = [...service.package.patterns, ...INCLUDES]
 
     await Promise.all(functionsToWrap.map(async (functionName) => {
       const { handler } = service.getFunction(functionName)


### PR DESCRIPTION
Support for `package.include` is [deprecated on Serverless Framework side](https://serverless.com/framework/docs/deprecations#new-way-to-define-packaging-patterns) and is scheduled to be removed with v3

This PR ensures that plugin internally relies on `package.patterns` as first choice.

I've additionally added `serverless` as peer dependency and indicated minimal version which supports `package.patterns`

I believe this should be considered as breaking change (as will stop working with Framework versions below 2.32.0) and should be released as a new major