### PR TITLE
Update build image to amazonlinux:2022.0.20220504.1-with-sources and fix dependencies

### DIFF
--- a/packages/lambda/builds/chromium/build/Dockerfile
+++ b/packages/lambda/builds/chromium/build/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -d --rm --name headless-chromium -p 9222:9222 adieuadieu/headless-chromium-for-aws-lambda
 #
 
-FROM amazonlinux:2.0.20200722.0-with-sources
+FROM amazonlinux:2022.0.20220504.1-with-sources
 
 # ref: https://chromium.googlesource.com/chromium/src.git/+refs
 ARG VERSION

--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -26,8 +26,8 @@ yum install -y \
   alsa-lib-devel atk-devel binutils bison bluez-libs-devel brlapi-devel \
   bzip2 bzip2-devel cairo-devel cmake cups-devel dbus-devel dbus-glib-devel \
   expat-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel glibc \
-  gperf gtk3-devel htop httpd java-1.*.0-openjdk-devel libatomic libcap-devel \
-  libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel \
+  gperf gtk3-devel httpd java-11-openjdk-devel libatomic libcap-devel \
+  libffi-devel libgcc libjpeg-devel libstdc++ libuuid-devel \
   libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial \
   mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel \
   pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python python3 \


### PR DESCRIPTION
I see that the builds have not been released in a while, so I attempted to build it first against 2.0.20220606.1, but this failed with /`lib64/libm.so.6: version ``GLIBC_2.27`' not found`.

I tried again with amazonlinux:2022.0.20220504.1, and this worked after changing the dependencies a bit.

I was able to connect with a remote debugger, but this is the extent of my testing at the moment.
Please let me know if this is of any use and/or how it would be best to proceed with this.
